### PR TITLE
Support Logical Types older representations(OriginalTypes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **column_options**: a map whose keys are name of columns, and values are configuration with following parameters (optional)
   - **timezone**: timezone if type of this column is timestamp. If not set, **default_timezone** is used. (string, optional)
   - **format**: timestamp format if type of this column is timestamp. If not set, **default_timestamp_format**: is used. (string, optional)
+  - **logical_type**: a Parquet logical type name (`timestamp-millis`, `timestamp-micros`, `json`, `int*`, `uint*`) (string, optional)
 - **canned_acl**: grants one of [canned ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL) for created objects (string, default: `private`)
 - **block_size**: The block size is the size of a row group being buffered in memory. This limits the memory usage when writing. Larger values will improve the I/O when reading but consume more memory when writing. (int, default: `134217728` (128MB))
 - **page_size**: The page size is for compression. When reading, each page can be decompressed independently. A block is composed of pages. The page is the smallest unit that must be read fully to access a single record. If this value is too small, the compression will deteriorate. (int, default: `1048576` (1MB))
@@ -75,6 +76,8 @@
   - **user** proxy user (string, optional)
   - **password** proxy password (string, optional)
 - **buffer_dir**: buffer directory for parquet files to be uploaded on S3 (string, default: Create a Temporary Directory)
+- **type_options**:  a map whose keys are name of embulk type(`boolean`, `long`, `double`, `string`, `timestamp`, `json`), and values are configuration with following parameters (optional)
+  - **logical_type**: a Parquet logical type name (`timestamp-millis`, `timestamp-micros`, `json`, `int*`, `uint*`) (string, optional)
 
 
 ## Example
@@ -92,7 +95,8 @@ out:
 
 ## Note
 
-* The current implementation does not support [LogicalTypes](https://github.com/apache/parquet-format/blob/2b38663/LogicalTypes.md). I will implement them later as **column_options**. So, currently **timestamp** type and **json** type are stored as UTF-8 String. Please be careful.  
+* The current Parquet [LogicalTypes](https://github.com/apache/parquet-format/blob/2b38663/LogicalTypes.md) implementation does only old representation.
+* Some kind of LogicalTypes are sometimes not supported on your middleware. Be careful to giving logical type name.
 
 ## Development
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.0.3"
+version = "0.0.4"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/example/with_logicaltypes.yml
+++ b/example/with_logicaltypes.yml
@@ -1,0 +1,35 @@
+
+in:
+  type: file
+  path_prefix: ./example/data.tsv
+  parser:
+    type: csv
+    delimiter: "\t"
+    skip_header_lines: 0
+    null_string: ""
+    columns:
+      - { name: id, type: long }
+      - { name: description, type: string }
+      - { name: name, type: string }
+      - { name: t, type: timestamp, format: "%Y-%m-%d %H:%M:%S %z"}
+      - { name: payload, type: json}
+    stop_on_invalid_record: true
+
+out:
+  type: s3_parquet
+  bucket: my-bucket
+  path_prefix: path/to/my-obj.
+  file_ext: snappy.parquet
+  compression_codec: snappy
+  default_timezone: Asia/Tokyo
+  canned_acl: bucket-owner-full-control
+  column_options:
+    # It has higher priority than type_options.timestamp
+    t:
+      logical_type: "timestamp-micros"
+  type_options:
+    json:
+      logical_type: "json"
+    # It should be ignored by column_options on 't' column
+    timestamp:
+      logical_type: "timestamp-millis"

--- a/example/with_logicaltypes.yml
+++ b/example/with_logicaltypes.yml
@@ -18,18 +18,14 @@ in:
 out:
   type: s3_parquet
   bucket: my-bucket
-  path_prefix: path/to/my-obj.
+  path_prefix: path/to/my-obj-2.
   file_ext: snappy.parquet
   compression_codec: snappy
   default_timezone: Asia/Tokyo
   canned_acl: bucket-owner-full-control
   column_options:
-    # It has higher priority than type_options.timestamp
-    t:
-      logical_type: "timestamp-micros"
+    id:
+      logical_type: "uint64"
   type_options:
-    json:
-      logical_type: "json"
-    # It should be ignored by column_options on 't' column
     timestamp:
       logical_type: "timestamp-millis"

--- a/src/main/scala/org/embulk/output/s3_parquet/S3ParquetOutputPlugin.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/S3ParquetOutputPlugin.scala
@@ -11,7 +11,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.embulk.config.{Config, ConfigDefault, ConfigDiff, ConfigException, ConfigSource, Task, TaskReport, TaskSource}
 import org.embulk.output.s3_parquet.S3ParquetOutputPlugin.PluginTask
 import org.embulk.output.s3_parquet.aws.Aws
-import org.embulk.output.s3_parquet.parquet.ParquetFileWriter
+import org.embulk.output.s3_parquet.parquet.{LogicalTypeHandlerStore, ParquetFileWriter}
 import org.embulk.spi.{Exec, OutputPlugin, PageReader, Schema, TransactionalPageOutput}
 import org.embulk.spi.time.TimestampFormatter
 import org.embulk.spi.time.TimestampFormatter.TimestampColumnOption
@@ -53,7 +53,7 @@ object S3ParquetOutputPlugin
 
         @Config("column_options")
         @ConfigDefault("{}")
-        def getColumnOptions: JMap[String, TimestampColumnOption]
+        def getColumnOptions: JMap[String, ColumnOptionTask]
 
         @Config("canned_acl")
         @ConfigDefault("\"private\"")
@@ -86,8 +86,20 @@ object S3ParquetOutputPlugin
         @Config("catalog")
         @ConfigDefault("null")
         def getCatalog: Optional[CatalogRegistrator.Task]
+
+        @Config("type_options")
+        @ConfigDefault("{}")
+        def getTypeOptions: JMap[String, TypeOptionTask]
     }
 
+    trait ColumnOptionTask extends Task with TimestampColumnOption with LogicalTypeOption
+
+    trait TypeOptionTask extends Task with LogicalTypeOption
+
+    trait LogicalTypeOption {
+        @Config("logical_type")
+        def getLogicalType: Optional[String]
+    }
 }
 
 class S3ParquetOutputPlugin
@@ -198,9 +210,11 @@ class S3ParquetOutputPlugin
         val pageReader: PageReader = new PageReader(schema)
         val aws: Aws = Aws(task)
         val timestampFormatters: Seq[TimestampFormatter] = Timestamps.newTimestampColumnFormatters(task, schema, task.getColumnOptions).toSeq
+        val logicalTypeHandlers = LogicalTypeHandlerStore.fromEmbulkOptions(task.getTypeOptions, task.getColumnOptions)
         val parquetWriter: ParquetWriter[PageReader] = ParquetFileWriter.builder()
             .withPath(bufferFile)
             .withSchema(schema)
+            .withLogicalTypeHandlers(logicalTypeHandlers)
             .withTimestampFormatters(timestampFormatters)
             .withCompressionCodec(task.getCompressionCodec)
             .withDictionaryEncoding(task.getEnableDictionaryEncoding.orElse(ParquetProperties.DEFAULT_IS_DICTIONARY_ENABLED))

--- a/src/main/scala/org/embulk/output/s3_parquet/S3ParquetOutputPlugin.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/S3ParquetOutputPlugin.scala
@@ -92,11 +92,14 @@ object S3ParquetOutputPlugin
         def getTypeOptions: JMap[String, TypeOptionTask]
     }
 
-    trait ColumnOptionTask extends Task with TimestampColumnOption with LogicalTypeOption
+    trait ColumnOptionTask
+        extends Task with TimestampColumnOption with LogicalTypeOption
 
-    trait TypeOptionTask extends Task with LogicalTypeOption
+    trait TypeOptionTask
+        extends Task with LogicalTypeOption
 
-    trait LogicalTypeOption {
+    trait LogicalTypeOption
+    {
         @Config("logical_type")
         def getLogicalType: Optional[String]
     }

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
@@ -55,7 +55,15 @@ object EmbulkMessageType
 
         override def longColumn(column: Column): Unit =
         {
-            builder.add(new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, column.getName))
+            val name = column.getName
+            val et = column.getType
+
+            val t = logicalTypeHandlers.get(name, et) match {
+                case Some(h) if h.isConvertible(et) => h.newSchemaFieldType(name)
+                case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, column.getName)
+            }
+
+            builder.add(t)
         }
 
         override def doubleColumn(column: Column): Unit =
@@ -71,9 +79,10 @@ object EmbulkMessageType
         override def timestampColumn(column: Column): Unit =
         {
             val name = column.getName
+            val et = column.getType
 
-            val t = logicalTypeHandlers.get(name, column.getType) match {
-                case Some(h) => h.newSchemaFieldType(name)
+            val t = logicalTypeHandlers.get(name, et) match {
+                case Some(h) if h.isConvertible(et) => h.newSchemaFieldType(name)
                 case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
             }
 
@@ -83,9 +92,10 @@ object EmbulkMessageType
         override def jsonColumn(column: Column): Unit =
         {
             val name = column.getName
+            val et = column.getType
 
-            val t = logicalTypeHandlers.get(name, column.getType) match {
-                case Some(h) => h.newSchemaFieldType(name)
+            val t = logicalTypeHandlers.get(name, et) match {
+                case Some(h) if h.isConvertible(et) => h.newSchemaFieldType(name)
                 case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
             }
 

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
@@ -1,5 +1,6 @@
 package org.embulk.output.s3_parquet.parquet
 
+
 import com.google.common.collect.ImmutableList
 import org.apache.parquet.schema.{MessageType, OriginalType, PrimitiveType, Type}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
@@ -60,7 +61,7 @@ object EmbulkMessageType
 
             val t = logicalTypeHandlers.get(name, et) match {
                 case Some(h) if h.isConvertible(et) => h.newSchemaFieldType(name)
-                case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, column.getName)
+                case _                              => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, column.getName)
             }
 
             builder.add(t)
@@ -83,7 +84,7 @@ object EmbulkMessageType
 
             val t = logicalTypeHandlers.get(name, et) match {
                 case Some(h) if h.isConvertible(et) => h.newSchemaFieldType(name)
-                case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
+                case _                              => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
             }
 
             builder.add(t)
@@ -96,7 +97,7 @@ object EmbulkMessageType
 
             val t = logicalTypeHandlers.get(name, et) match {
                 case Some(h) if h.isConvertible(et) => h.newSchemaFieldType(name)
-                case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
+                case _                              => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
             }
 
             builder.add(t)

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
@@ -1,6 +1,5 @@
 package org.embulk.output.s3_parquet.parquet
 
-
 import com.google.common.collect.ImmutableList
 import org.apache.parquet.schema.{MessageType, OriginalType, PrimitiveType, Type}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
@@ -16,30 +15,36 @@ object EmbulkMessageType
     }
 
     case class Builder(name: String = "embulk",
-                       schema: Schema = Schema.builder().build())
+                       schema: Schema = Schema.builder().build(),
+                       logicalTypeHandlers: LogicalTypeHandlerStore = LogicalTypeHandlerStore.empty)
     {
 
         def withName(name: String): Builder =
         {
-            Builder(name = name, schema = schema)
+            Builder(name = name, schema = schema, logicalTypeHandlers = logicalTypeHandlers)
         }
 
         def withSchema(schema: Schema): Builder =
         {
-            Builder(name = name, schema = schema)
+            Builder(name = name, schema = schema, logicalTypeHandlers = logicalTypeHandlers)
+        }
+
+        def withLogicalTypeHandlers(logicalTypeHandlers: LogicalTypeHandlerStore): Builder =
+        {
+            Builder(name = name, schema = schema, logicalTypeHandlers = logicalTypeHandlers)
         }
 
         def build(): MessageType =
         {
             val builder: ImmutableList.Builder[Type] = ImmutableList.builder[Type]()
-            schema.visitColumns(EmbulkMessageTypeColumnVisitor(builder))
+            schema.visitColumns(EmbulkMessageTypeColumnVisitor(builder, logicalTypeHandlers))
             new MessageType("embulk", builder.build())
-
         }
 
     }
 
-    private case class EmbulkMessageTypeColumnVisitor(builder: ImmutableList.Builder[Type])
+    private case class EmbulkMessageTypeColumnVisitor(builder: ImmutableList.Builder[Type],
+                                                      logicalTypeHandlers: LogicalTypeHandlerStore = LogicalTypeHandlerStore.empty)
         extends ColumnVisitor
     {
 
@@ -65,14 +70,26 @@ object EmbulkMessageType
 
         override def timestampColumn(column: Column): Unit =
         {
-            // TODO: Support OriginalType.TIME* ?
-            builder.add(new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, column.getName, OriginalType.UTF8))
+            val name = column.getName
+
+            val t = logicalTypeHandlers.get(column.getType, name) match {
+                case Some(h) => h.newSchemaFieldType(name)
+                case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
+            }
+
+            builder.add(t)
         }
 
         override def jsonColumn(column: Column): Unit =
         {
-            // TODO: does this work?
-            builder.add(new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, column.getName, OriginalType.UTF8))
+            val name = column.getName
+
+            val t = logicalTypeHandlers.get(column.getType, name) match {
+                case Some(h) => h.newSchemaFieldType(name)
+                case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
+            }
+
+            builder.add(t)
         }
     }
 

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/EmbulkMessageType.scala
@@ -72,7 +72,7 @@ object EmbulkMessageType
         {
             val name = column.getName
 
-            val t = logicalTypeHandlers.get(column.getType, name) match {
+            val t = logicalTypeHandlers.get(name, column.getType) match {
                 case Some(h) => h.newSchemaFieldType(name)
                 case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
             }
@@ -84,7 +84,7 @@ object EmbulkMessageType
         {
             val name = column.getName
 
-            val t = logicalTypeHandlers.get(column.getType, name) match {
+            val t = logicalTypeHandlers.get(name, column.getType) match {
                 case Some(h) => h.newSchemaFieldType(name)
                 case _ => new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.UTF8)
             }

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
@@ -3,6 +3,7 @@ package org.embulk.output.s3_parquet.parquet
 import org.apache.parquet.io.api.{Binary, RecordConsumer}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.{OriginalType, PrimitiveType, Type}
+import org.embulk.spi.DataException
 import org.embulk.spi.time.Timestamp
 import org.msgpack.value.Value
 
@@ -27,7 +28,7 @@ case class TimestampMillisLogicalTypeHandler() extends LogicalTypeHandler {
     override def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit =
         orig match {
             case ts: Timestamp => recordConsumer.addLong(ts.toEpochMilli)
-            case _ => throw new IllegalArgumentException("given mismatched type value")
+            case _ => throw new DataException("given mismatched type value")
         }
 }
 
@@ -40,7 +41,7 @@ case class TimestampMicrosLogicalTypeHandler() extends LogicalTypeHandler {
             case ts: Timestamp =>
                 val v = (ts.getEpochSecond * 1_000_000L) + (ts.getNano.asInstanceOf[Long] / 1_000L)
                 recordConsumer.addLong(v)
-            case _ => throw new IllegalArgumentException("given mismatched type value")
+            case _ => throw new DataException("given mismatched type value")
         }
 }
 
@@ -53,6 +54,6 @@ case class JsonLogicalTypeHandler() extends LogicalTypeHandler {
             case msgPack: Value =>
                 val bin = Binary.fromString(msgPack.toJson)
                 recordConsumer.addBinary(bin)
-            case _ => throw new IllegalArgumentException("given mismatched type value")
+            case _ => throw new DataException("given mismatched type value")
         }
 }

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
@@ -18,17 +18,28 @@ import org.msgpack.value.Value
 trait LogicalTypeHandler {
     def newSchemaFieldType(name: String): PrimitiveType
 
-    def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit
+    def consume(orig: Any, recordConsumer: RecordConsumer): Unit
+}
+
+private case class IntLogicalTypeHandler(ot: OriginalType) extends LogicalTypeHandler {
+    override def newSchemaFieldType(name: String): PrimitiveType =
+        new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, ot)
+
+    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
+        orig match {
+            case v: Long => recordConsumer.addLong(v)
+            case _ => throw new DataException("given mismatched type value; expected type is long")
+        }
 }
 
 case class TimestampMillisLogicalTypeHandler() extends LogicalTypeHandler {
     override def newSchemaFieldType(name: String): PrimitiveType =
         new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, OriginalType.TIMESTAMP_MILLIS)
 
-    override def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit =
+    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
         orig match {
             case ts: Timestamp => recordConsumer.addLong(ts.toEpochMilli)
-            case _ => throw new DataException("given mismatched type value")
+            case _ => throw new DataException("given mismatched type value; expected type is timestamp")
         }
 }
 
@@ -36,24 +47,34 @@ case class TimestampMicrosLogicalTypeHandler() extends LogicalTypeHandler {
     override def newSchemaFieldType(name: String): PrimitiveType =
         new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, OriginalType.TIMESTAMP_MICROS)
 
-    override def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit =
+    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
         orig match {
             case ts: Timestamp =>
                 val v = (ts.getEpochSecond * 1_000_000L) + (ts.getNano.asInstanceOf[Long] / 1_000L)
                 recordConsumer.addLong(v)
-            case _ => throw new DataException("given mismatched type value")
+            case _ => throw new DataException("given mismatched type value; expected type is timestamp")
         }
 }
+
+case class Int8LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.INT_8)
+case class Int16LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.INT_16)
+case class Int32LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.INT_32)
+case class Int64LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.INT_64)
+
+case class Uint8LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.UINT_8)
+case class Uint16LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.UINT_16)
+case class Uint32LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.UINT_32)
+case class Uint64LogicalTypeHandler() extends IntLogicalTypeHandler(OriginalType.UINT_64)
 
 case class JsonLogicalTypeHandler() extends LogicalTypeHandler {
     override def newSchemaFieldType(name: String): PrimitiveType =
         new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.JSON)
 
-    override def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit =
+    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
         orig match {
             case msgPack: Value =>
                 val bin = Binary.fromString(msgPack.toJson)
                 recordConsumer.addBinary(bin)
-            case _ => throw new DataException("given mismatched type value")
+            case _ => throw new DataException("given mismatched type value; expected type is json")
         }
 }

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
@@ -1,5 +1,6 @@
 package org.embulk.output.s3_parquet.parquet
 
+
 import org.apache.parquet.io.api.{Binary, RecordConsumer}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.apache.parquet.schema.{Type => PType}
@@ -10,6 +11,7 @@ import org.embulk.spi.`type`.Types
 import org.embulk.spi.time.Timestamp
 import org.msgpack.value.Value
 
+
 /**
  * Handle Apache Parquet 'Logical Types' on schema/value conversion.
  * ref. https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
@@ -18,76 +20,126 @@ import org.msgpack.value.Value
  * TODO Support both of older and newer representation after 1.11+ is published and other middleware supports it.
  *
  */
-sealed trait LogicalTypeHandler {
+sealed trait LogicalTypeHandler
+{
     def isConvertible(t: EType): Boolean
 
     def newSchemaFieldType(name: String): PrimitiveType
 
-    def consume(orig: Any, recordConsumer: RecordConsumer): Unit
+    def consume(orig: Any,
+                recordConsumer: RecordConsumer): Unit
 }
 
-abstract class IntLogicalTypeHandler(ot: OriginalType) extends LogicalTypeHandler {
-    override def isConvertible(t: EType): Boolean = t == Types.LONG
+abstract class IntLogicalTypeHandler(ot: OriginalType)
+    extends LogicalTypeHandler
+{
+    override def isConvertible(t: EType): Boolean =
+    {
+        t == Types.LONG
+    }
 
     override def newSchemaFieldType(name: String): PrimitiveType =
+    {
         new PrimitiveType(PType.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, ot)
+    }
 
-    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
+    override def consume(orig: Any,
+                         recordConsumer: RecordConsumer): Unit =
+    {
         orig match {
             case v: Long => recordConsumer.addLong(v)
-            case _ => throw new DataException("given mismatched type value; expected type is long")
+            case _       => throw new DataException("given mismatched type value; expected type is long")
         }
+    }
 }
 
-object TimestampMillisLogicalTypeHandler extends LogicalTypeHandler {
-    override def isConvertible(t: EType): Boolean = t == Types.TIMESTAMP
+object TimestampMillisLogicalTypeHandler
+    extends LogicalTypeHandler
+{
+    override def isConvertible(t: EType): Boolean =
+    {
+        t == Types.TIMESTAMP
+    }
 
     override def newSchemaFieldType(name: String): PrimitiveType =
+    {
         new PrimitiveType(PType.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, OriginalType.TIMESTAMP_MILLIS)
+    }
 
-    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
+    override def consume(orig: Any,
+                         recordConsumer: RecordConsumer): Unit =
+    {
         orig match {
             case ts: Timestamp => recordConsumer.addLong(ts.toEpochMilli)
-            case _ => throw new DataException("given mismatched type value; expected type is timestamp")
+            case _             => throw new DataException("given mismatched type value; expected type is timestamp")
         }
+    }
 }
 
-object TimestampMicrosLogicalTypeHandler extends LogicalTypeHandler {
-    override def isConvertible(t: EType): Boolean = t == Types.TIMESTAMP
+object TimestampMicrosLogicalTypeHandler
+    extends LogicalTypeHandler
+{
+    override def isConvertible(t: EType): Boolean =
+    {
+        t == Types.TIMESTAMP
+    }
 
     override def newSchemaFieldType(name: String): PrimitiveType =
+    {
         new PrimitiveType(PType.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, OriginalType.TIMESTAMP_MICROS)
+    }
 
-    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
+    override def consume(orig: Any,
+                         recordConsumer: RecordConsumer): Unit =
+    {
         orig match {
             case ts: Timestamp =>
                 val v = (ts.getEpochSecond * 1_000_000L) + (ts.getNano.asInstanceOf[Long] / 1_000L)
                 recordConsumer.addLong(v)
-            case _ => throw new DataException("given mismatched type value; expected type is timestamp")
+            case _             => throw new DataException("given mismatched type value; expected type is timestamp")
         }
+    }
 }
 
-object Int8LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.INT_8)
-object Int16LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.INT_16)
-object Int32LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.INT_32)
-object Int64LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.INT_64)
+object Int8LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.INT_8)
+object Int16LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.INT_16)
+object Int32LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.INT_32)
+object Int64LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.INT_64)
 
-object Uint8LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.UINT_8)
-object Uint16LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.UINT_16)
-object Uint32LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.UINT_32)
-object Uint64LogicalTypeHandler extends IntLogicalTypeHandler(OriginalType.UINT_64)
+object Uint8LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.UINT_8)
+object Uint16LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.UINT_16)
+object Uint32LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.UINT_32)
+object Uint64LogicalTypeHandler
+    extends IntLogicalTypeHandler(OriginalType.UINT_64)
 
-object JsonLogicalTypeHandler extends LogicalTypeHandler {
-    override def isConvertible(t: EType): Boolean = t == Types.JSON
+object JsonLogicalTypeHandler
+    extends LogicalTypeHandler
+{
+    override def isConvertible(t: EType): Boolean =
+    {
+        t == Types.JSON
+    }
 
     override def newSchemaFieldType(name: String): PrimitiveType =
+    {
         new PrimitiveType(PType.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.JSON)
+    }
 
-    override def consume(orig: Any, recordConsumer: RecordConsumer): Unit =
+    override def consume(orig: Any,
+                         recordConsumer: RecordConsumer): Unit =
+    {
         orig match {
             case msgPack: Value =>
                 val bin = Binary.fromString(msgPack.toJson)
                 recordConsumer.addBinary(bin)
-            case _ => throw new DataException("given mismatched type value; expected type is json")
+            case _              => throw new DataException("given mismatched type value; expected type is json")
         }
+    }
 }

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandler.scala
@@ -1,0 +1,58 @@
+package org.embulk.output.s3_parquet.parquet
+
+import org.apache.parquet.io.api.{Binary, RecordConsumer}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+import org.apache.parquet.schema.{OriginalType, PrimitiveType, Type}
+import org.embulk.spi.time.Timestamp
+import org.msgpack.value.Value
+
+/**
+ * Handle Apache Parquet 'Logical Types' on schema/value conversion.
+ * ref. https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+ *
+ * It focuses on only older representation because newer supported since 1.11 is not used actually yet.
+ * TODO Support both of older and newer representation after 1.11+ is published and other middleware supports it.
+ *
+ */
+trait LogicalTypeHandler {
+    def newSchemaFieldType(name: String): PrimitiveType
+
+    def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit
+}
+
+case class TimestampMillisLogicalTypeHandler() extends LogicalTypeHandler {
+    override def newSchemaFieldType(name: String): PrimitiveType =
+        new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, OriginalType.TIMESTAMP_MILLIS)
+
+    override def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit =
+        orig match {
+            case ts: Timestamp => recordConsumer.addLong(ts.toEpochMilli)
+            case _ => throw new IllegalArgumentException("given mismatched type value")
+        }
+}
+
+case class TimestampMicrosLogicalTypeHandler() extends LogicalTypeHandler {
+    override def newSchemaFieldType(name: String): PrimitiveType =
+        new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.INT64, name, OriginalType.TIMESTAMP_MICROS)
+
+    override def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit =
+        orig match {
+            case ts: Timestamp =>
+                val v = (ts.getEpochSecond * 1_000_000L) + (ts.getNano.asInstanceOf[Long] / 1_000L)
+                recordConsumer.addLong(v)
+            case _ => throw new IllegalArgumentException("given mismatched type value")
+        }
+}
+
+case class JsonLogicalTypeHandler() extends LogicalTypeHandler {
+    override def newSchemaFieldType(name: String): PrimitiveType =
+        new PrimitiveType(Type.Repetition.OPTIONAL, PrimitiveTypeName.BINARY, name, OriginalType.JSON)
+
+    override def consume(orig: AnyRef, recordConsumer: RecordConsumer): Unit =
+        orig match {
+            case msgPack: Value =>
+                val bin = Binary.fromString(msgPack.toJson)
+                recordConsumer.addBinary(bin)
+            case _ => throw new IllegalArgumentException("given mismatched type value")
+        }
+}

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandlerStore.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandlerStore.scala
@@ -48,8 +48,15 @@ object LogicalTypeHandlerStore {
     private val STRING_TO_LOGICAL_TYPE = Map[String, LogicalTypeHandler](
         "timestamp-millis" -> TimestampMillisLogicalTypeHandler(),
         "timestamp-micros" -> TimestampMicrosLogicalTypeHandler(),
+        "int8" -> Int8LogicalTypeHandler(),
+        "int16" -> Int16LogicalTypeHandler(),
+        "int32" -> Int32LogicalTypeHandler(),
+        "int64" -> Int64LogicalTypeHandler(),
+        "uint8" -> Uint8LogicalTypeHandler(),
+        "uint16" -> Uint16LogicalTypeHandler(),
+        "uint32" -> Uint32LogicalTypeHandler(),
+        "uint64" -> Uint64LogicalTypeHandler(),
         "json" -> JsonLogicalTypeHandler()
-        // TODO other types ...
     )
 
     def empty: LogicalTypeHandlerStore =

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandlerStore.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandlerStore.scala
@@ -1,0 +1,78 @@
+package org.embulk.output.s3_parquet.parquet
+
+import org.embulk.spi.`type`.{Type, Types}
+import java.util.{Map => JMap}
+
+import org.embulk.output.s3_parquet.S3ParquetOutputPlugin.{ColumnOptionTask, TypeOptionTask}
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * A storage has mapping from logical type query (column name, type) to handler.
+ *
+ * @param fromEmbulkType
+ * @param fromColumnName
+ */
+case class LogicalTypeHandlerStore private (fromEmbulkType: Map[Type, LogicalTypeHandler],
+                                            fromColumnName: Map[String, LogicalTypeHandler]) {
+
+    // Try column name lookup, then column type
+    def get(n: String, t: Type): Option[LogicalTypeHandler] =
+        get(n) match {
+            case Some(h) => Some(h)
+            case _ =>
+                get(t) match {
+                    case Some(h) => Some(h)
+                    case _ => None
+                }
+        }
+
+    def get(t: Type): Option[LogicalTypeHandler] =
+        fromEmbulkType.get(t)
+
+    def get(n: String): Option[LogicalTypeHandler] =
+        fromColumnName.get(n)
+}
+
+object LogicalTypeHandlerStore {
+    private val STRING_TO_EMBULK_TYPE = Map[String, Type](
+        "boolean" -> Types.BOOLEAN,
+        "long" -> Types.LONG,
+        "double" -> Types.DOUBLE,
+        "string" -> Types.STRING,
+        "timestamp" -> Types.TIMESTAMP,
+        "json" -> Types.JSON
+    )
+
+    // Listed only older logical types that we can convert from embulk type
+    private val STRING_TO_LOGICAL_TYPE = Map[String, LogicalTypeHandler](
+        "timestamp-millis" -> TimestampMillisLogicalTypeHandler(),
+        "timestamp-micros" -> TimestampMicrosLogicalTypeHandler(),
+        "json" -> JsonLogicalTypeHandler()
+        // TODO other types ...
+    )
+
+    def empty: LogicalTypeHandlerStore =
+        LogicalTypeHandlerStore(Map.empty[Type, LogicalTypeHandler], Map.empty[String, LogicalTypeHandler])
+
+    def fromEmbulkOptions(typeOpts: JMap[String, TypeOptionTask], columnOpts: JMap[String, ColumnOptionTask]): LogicalTypeHandlerStore = {
+        val fromEmbulkType = typeOpts.asScala
+            .filter(_._2.getLogicalType.isPresent)
+            .map[Type, LogicalTypeHandler] { case (k, v) =>
+                val t = STRING_TO_EMBULK_TYPE(k)
+                val h = STRING_TO_LOGICAL_TYPE(v.getLogicalType.get)
+                (t, h)
+            }
+            .toMap
+
+        val fromColumnName = columnOpts.asScala
+            .filter(_._2.getLogicalType.isPresent)
+            .map[String, LogicalTypeHandler] { case (k, v) =>
+                val h = STRING_TO_LOGICAL_TYPE(v.getLogicalType.get)
+                (k, h)
+            }
+            .toMap
+
+        LogicalTypeHandlerStore(fromEmbulkType, fromColumnName)
+    }
+}

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandlerStore.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/LogicalTypeHandlerStore.scala
@@ -3,6 +3,7 @@ package org.embulk.output.s3_parquet.parquet
 import org.embulk.spi.`type`.{Type, Types}
 import java.util.{Map => JMap}
 
+import org.embulk.config.ConfigException
 import org.embulk.output.s3_parquet.S3ParquetOutputPlugin.{ColumnOptionTask, TypeOptionTask}
 
 import scala.jdk.CollectionConverters._
@@ -46,17 +47,17 @@ object LogicalTypeHandlerStore {
 
     // Listed only older logical types that we can convert from embulk type
     private val STRING_TO_LOGICAL_TYPE = Map[String, LogicalTypeHandler](
-        "timestamp-millis" -> TimestampMillisLogicalTypeHandler(),
-        "timestamp-micros" -> TimestampMicrosLogicalTypeHandler(),
-        "int8" -> Int8LogicalTypeHandler(),
-        "int16" -> Int16LogicalTypeHandler(),
-        "int32" -> Int32LogicalTypeHandler(),
-        "int64" -> Int64LogicalTypeHandler(),
-        "uint8" -> Uint8LogicalTypeHandler(),
-        "uint16" -> Uint16LogicalTypeHandler(),
-        "uint32" -> Uint32LogicalTypeHandler(),
-        "uint64" -> Uint64LogicalTypeHandler(),
-        "json" -> JsonLogicalTypeHandler()
+        "timestamp-millis" -> TimestampMillisLogicalTypeHandler,
+        "timestamp-micros" -> TimestampMicrosLogicalTypeHandler,
+        "int8" -> Int8LogicalTypeHandler,
+        "int16" -> Int16LogicalTypeHandler,
+        "int32" -> Int32LogicalTypeHandler,
+        "int64" -> Int64LogicalTypeHandler,
+        "uint8" -> Uint8LogicalTypeHandler,
+        "uint16" -> Uint16LogicalTypeHandler,
+        "uint32" -> Uint32LogicalTypeHandler,
+        "uint64" -> Uint64LogicalTypeHandler,
+        "json" -> JsonLogicalTypeHandler
     )
 
     def empty: LogicalTypeHandlerStore =
@@ -66,17 +67,23 @@ object LogicalTypeHandlerStore {
         val fromEmbulkType = typeOpts.asScala
             .filter(_._2.getLogicalType.isPresent)
             .map[Type, LogicalTypeHandler] { case (k, v) =>
-                val t = STRING_TO_EMBULK_TYPE(k)
-                val h = STRING_TO_LOGICAL_TYPE(v.getLogicalType.get)
-                (t, h)
+                val t = STRING_TO_EMBULK_TYPE.get(k)
+                val h = STRING_TO_LOGICAL_TYPE.get(v.getLogicalType.get)
+                (t, h) match {
+                    case (Some(tt), Some(hh)) => (tt, hh)
+                    case _ => throw new ConfigException("invalid logical types in type_options")
+                }
             }
             .toMap
 
         val fromColumnName = columnOpts.asScala
             .filter(_._2.getLogicalType.isPresent)
             .map[String, LogicalTypeHandler] { case (k, v) =>
-                val h = STRING_TO_LOGICAL_TYPE(v.getLogicalType.get)
-                (k, h)
+                val h = STRING_TO_LOGICAL_TYPE.get(v.getLogicalType.get)
+                h match {
+                    case Some(hh) => (k, hh)
+                    case _ => throw new ConfigException("invalid logical types in column_options")
+                }
             }
             .toMap
 

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/ParquetFileWriteSupport.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/ParquetFileWriteSupport.scala
@@ -13,7 +13,8 @@ import scala.jdk.CollectionConverters._
 
 
 private[parquet] case class ParquetFileWriteSupport(schema: Schema,
-                                                    timestampFormatters: Seq[TimestampFormatter])
+                                                    timestampFormatters: Seq[TimestampFormatter],
+                                                    logicalTypeHandlers: LogicalTypeHandlerStore = LogicalTypeHandlerStore.empty)
     extends WriteSupport[PageReader]
 {
 
@@ -23,6 +24,7 @@ private[parquet] case class ParquetFileWriteSupport(schema: Schema,
     {
         val messageType: MessageType = EmbulkMessageType.builder()
             .withSchema(schema)
+            .withLogicalTypeHandlers(logicalTypeHandlers)
             .build()
         val metadata: Map[String, String] = Map.empty // NOTE: When is this used?
         new WriteContext(messageType, metadata.asJava)
@@ -30,7 +32,7 @@ private[parquet] case class ParquetFileWriteSupport(schema: Schema,
 
     override def prepareForWrite(recordConsumer: RecordConsumer): Unit =
     {
-        currentParquetFileWriter = ParquetFileWriter(recordConsumer, schema, timestampFormatters)
+        currentParquetFileWriter = ParquetFileWriter(recordConsumer, schema, timestampFormatters, logicalTypeHandlers)
     }
 
     override def write(record: PageReader): Unit =

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/ParquetFileWriter.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/ParquetFileWriter.scala
@@ -15,7 +15,8 @@ object ParquetFileWriter
 
     case class Builder(path: Path = null,
                        schema: Schema = null,
-                       timestampFormatters: Seq[TimestampFormatter] = null)
+                       timestampFormatters: Seq[TimestampFormatter] = null,
+                       logicalTypeHandlers: LogicalTypeHandlerStore = LogicalTypeHandlerStore.empty)
         extends ParquetWriter.Builder[PageReader, Builder](path)
     {
 
@@ -39,6 +40,11 @@ object ParquetFileWriter
         copy(timestampFormatters = timestampFormatters)
       }
 
+      def withLogicalTypeHandlers(logicalTypeHandlers: LogicalTypeHandlerStore): Builder =
+      {
+        copy(logicalTypeHandlers = logicalTypeHandlers)
+      }
+
       override def self(): Builder =
       {
         this
@@ -46,7 +52,7 @@ object ParquetFileWriter
 
         override def getWriteSupport(conf: Configuration): WriteSupport[PageReader] =
         {
-            ParquetFileWriteSupport(schema, timestampFormatters)
+            ParquetFileWriteSupport(schema, timestampFormatters, logicalTypeHandlers)
         }
     }
 
@@ -60,10 +66,11 @@ object ParquetFileWriter
 
 private[parquet] case class ParquetFileWriter(recordConsumer: RecordConsumer,
                                               schema: Schema,
-                                              timestampFormatters: Seq[TimestampFormatter])
+                                              timestampFormatters: Seq[TimestampFormatter],
+                                              logicalTypeHandlers: LogicalTypeHandlerStore = LogicalTypeHandlerStore.empty)
 {
 
-    def write(record: PageReader): Unit =
+  def write(record: PageReader): Unit =
     {
         recordConsumer.startMessage()
         writeRecord(record)
@@ -117,11 +124,16 @@ private[parquet] case class ParquetFileWriter(recordConsumer: RecordConsumer,
             {
                 nullOr(column, {
                     withWriteFieldContext(column, {
-                        // TODO: is a correct way to convert for parquet ?
                         val t = record.getTimestamp(column)
-                        val ft = timestampFormatters(column.getIndex).format(t)
-                        val bin = Binary.fromString(ft)
-                        recordConsumer.addBinary(bin)
+
+                      logicalTypeHandlers.get(column.getName, column.getType) match {
+                            case Some(h) =>
+                              h.consume(t, recordConsumer)
+                            case _ =>
+                              val ft = timestampFormatters(column.getIndex).format(t)
+                              val bin = Binary.fromString(ft)
+                              recordConsumer.addBinary(bin)
+                        }
                     })
                 })
             }
@@ -130,10 +142,15 @@ private[parquet] case class ParquetFileWriter(recordConsumer: RecordConsumer,
             {
                 nullOr(column, {
                     withWriteFieldContext(column, {
-                        // TODO: is a correct way to convert for parquet ?
                         val msgPack = record.getJson(column)
-                        val bin = Binary.fromString(msgPack.toJson)
-                        recordConsumer.addBinary(bin)
+
+                        logicalTypeHandlers.get(column.getName, column.getType) match {
+                            case Some(h) =>
+                                h.consume(msgPack, recordConsumer)
+                            case _ =>
+                                val bin = Binary.fromString(msgPack.toJson)
+                                recordConsumer.addBinary(bin)
+                        }
                     })
                 })
             }

--- a/src/main/scala/org/embulk/output/s3_parquet/parquet/ParquetFileWriter.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/parquet/ParquetFileWriter.scala
@@ -20,35 +20,35 @@ object ParquetFileWriter
         extends ParquetWriter.Builder[PageReader, Builder](path)
     {
 
-      def withPath(path: Path): Builder =
-      {
-        copy(path = path)
-      }
+        def withPath(path: Path): Builder =
+        {
+            copy(path = path)
+        }
 
-      def withPath(pathString: String): Builder =
-      {
-        copy(path = new Path(pathString))
-      }
+        def withPath(pathString: String): Builder =
+        {
+            copy(path = new Path(pathString))
+        }
 
-      def withSchema(schema: Schema): Builder =
-      {
-        copy(schema = schema)
-      }
+        def withSchema(schema: Schema): Builder =
+        {
+            copy(schema = schema)
+        }
 
-      def withTimestampFormatters(timestampFormatters: Seq[TimestampFormatter]): Builder =
-      {
-        copy(timestampFormatters = timestampFormatters)
-      }
+        def withTimestampFormatters(timestampFormatters: Seq[TimestampFormatter]): Builder =
+        {
+            copy(timestampFormatters = timestampFormatters)
+        }
 
-      def withLogicalTypeHandlers(logicalTypeHandlers: LogicalTypeHandlerStore): Builder =
-      {
-        copy(logicalTypeHandlers = logicalTypeHandlers)
-      }
+        def withLogicalTypeHandlers(logicalTypeHandlers: LogicalTypeHandlerStore): Builder =
+        {
+            copy(logicalTypeHandlers = logicalTypeHandlers)
+        }
 
-      override def self(): Builder =
-      {
-        this
-      }
+        override def self(): Builder =
+        {
+            this
+        }
 
         override def getWriteSupport(conf: Configuration): WriteSupport[PageReader] =
         {
@@ -56,10 +56,10 @@ object ParquetFileWriter
         }
     }
 
-  def builder(): Builder =
-  {
-    Builder()
-  }
+    def builder(): Builder =
+    {
+        Builder()
+    }
 
 }
 
@@ -70,7 +70,7 @@ private[parquet] case class ParquetFileWriter(recordConsumer: RecordConsumer,
                                               logicalTypeHandlers: LogicalTypeHandlerStore = LogicalTypeHandlerStore.empty)
 {
 
-  def write(record: PageReader): Unit =
+    def write(record: PageReader): Unit =
     {
         recordConsumer.startMessage()
         writeRecord(record)
@@ -126,13 +126,13 @@ private[parquet] case class ParquetFileWriter(recordConsumer: RecordConsumer,
                     withWriteFieldContext(column, {
                         val t = record.getTimestamp(column)
 
-                      logicalTypeHandlers.get(column.getName, column.getType) match {
+                        logicalTypeHandlers.get(column.getName, column.getType) match {
                             case Some(h) =>
-                              h.consume(t, recordConsumer)
-                            case _ =>
-                              val ft = timestampFormatters(column.getIndex).format(t)
-                              val bin = Binary.fromString(ft)
-                              recordConsumer.addBinary(bin)
+                                h.consume(t, recordConsumer)
+                            case _       =>
+                                val ft = timestampFormatters(column.getIndex).format(t)
+                                val bin = Binary.fromString(ft)
+                                recordConsumer.addBinary(bin)
                         }
                     })
                 })
@@ -147,7 +147,7 @@ private[parquet] case class ParquetFileWriter(recordConsumer: RecordConsumer,
                         logicalTypeHandlers.get(column.getName, column.getType) match {
                             case Some(h) =>
                                 h.consume(msgPack, recordConsumer)
-                            case _ =>
+                            case _       =>
                                 val bin = Binary.fromString(msgPack.toJson)
                                 recordConsumer.addBinary(bin)
                         }

--- a/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandler.scala
+++ b/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandler.scala
@@ -1,5 +1,6 @@
 package org.embulk.output.s3_parquet.parquet
 
+
 import org.embulk.spi.DataException
 import org.embulk.spi.`type`.Types
 import org.junit.runner.RunWith
@@ -8,67 +9,70 @@ import org.scalatest.junit.JUnitRunner
 
 import scala.util.Try
 
+
 @RunWith(classOf[JUnitRunner])
-class TestLogicalTypeHandler extends FunSuite {
+class TestLogicalTypeHandler
+    extends FunSuite
+{
 
-  test("IntLogicalTypeHandler.isConvertible() returns true for long") {
-    val h = Int8LogicalTypeHandler
+    test("IntLogicalTypeHandler.isConvertible() returns true for long") {
+        val h = Int8LogicalTypeHandler
 
-    assert(h.isConvertible(Types.LONG))
-    assert(!h.isConvertible(Types.BOOLEAN))
-  }
+        assert(h.isConvertible(Types.LONG))
+        assert(!h.isConvertible(Types.BOOLEAN))
+    }
 
-  test("IntLogicalTypeHandler.consume() raises DataException if given type is not long") {
-    val h = Int8LogicalTypeHandler
-    val actual = Try(h.consume("invalid", null))
+    test("IntLogicalTypeHandler.consume() raises DataException if given type is not long") {
+        val h = Int8LogicalTypeHandler
+        val actual = Try(h.consume("invalid", null))
 
-    assert(actual.isFailure)
-    assert(actual.failed.get.isInstanceOf[DataException])
-  }
-
-
-  test("TimestampMillisLogicalTypeHandler.isConvertible() returns true for timestamp") {
-    val h = TimestampMillisLogicalTypeHandler
-
-    assert(h.isConvertible(Types.TIMESTAMP))
-    assert(!h.isConvertible(Types.BOOLEAN))
-  }
-
-  test("TimestampMillisLogicalTypeHandler.consume() raises DataException if given type is not timestamp") {
-    val h = TimestampMillisLogicalTypeHandler
-    val actual = Try(h.consume("invalid", null))
-
-    assert(actual.isFailure)
-    assert(actual.failed.get.isInstanceOf[DataException])
-  }
+        assert(actual.isFailure)
+        assert(actual.failed.get.isInstanceOf[DataException])
+    }
 
 
-  test("TimestampMicrosLogicalTypeHandler.isConvertible() returns true for timestamp") {
-    val h = TimestampMicrosLogicalTypeHandler
+    test("TimestampMillisLogicalTypeHandler.isConvertible() returns true for timestamp") {
+        val h = TimestampMillisLogicalTypeHandler
 
-    assert(h.isConvertible(Types.TIMESTAMP))
-    assert(!h.isConvertible(Types.BOOLEAN))
-  }
+        assert(h.isConvertible(Types.TIMESTAMP))
+        assert(!h.isConvertible(Types.BOOLEAN))
+    }
 
-  test("TimestampMicrosLogicalTypeHandler.consume() raises DataException if given type is not timestamp") {
-    val h = TimestampMicrosLogicalTypeHandler
-    val actual = Try(h.consume("invalid", null))
+    test("TimestampMillisLogicalTypeHandler.consume() raises DataException if given type is not timestamp") {
+        val h = TimestampMillisLogicalTypeHandler
+        val actual = Try(h.consume("invalid", null))
 
-    assert(actual.isFailure)
-    assert(actual.failed.get.isInstanceOf[DataException])
-  }
+        assert(actual.isFailure)
+        assert(actual.failed.get.isInstanceOf[DataException])
+    }
 
-  test("JsonLogicalTypeHandler.isConvertible() returns true for json") {
-    val h = JsonLogicalTypeHandler
 
-    assert(h.isConvertible(Types.JSON))
-    assert(!h.isConvertible(Types.BOOLEAN))
-  }
+    test("TimestampMicrosLogicalTypeHandler.isConvertible() returns true for timestamp") {
+        val h = TimestampMicrosLogicalTypeHandler
 
-  test("JsonLogicalTypeHandler.consume() raises DataException if given type is not json") {
-    val h = JsonLogicalTypeHandler
-    val actual = Try(h.consume("invalid", null))
-    assert(actual.isFailure)
-    assert(actual.failed.get.isInstanceOf[DataException])
-  }
+        assert(h.isConvertible(Types.TIMESTAMP))
+        assert(!h.isConvertible(Types.BOOLEAN))
+    }
+
+    test("TimestampMicrosLogicalTypeHandler.consume() raises DataException if given type is not timestamp") {
+        val h = TimestampMicrosLogicalTypeHandler
+        val actual = Try(h.consume("invalid", null))
+
+        assert(actual.isFailure)
+        assert(actual.failed.get.isInstanceOf[DataException])
+    }
+
+    test("JsonLogicalTypeHandler.isConvertible() returns true for json") {
+        val h = JsonLogicalTypeHandler
+
+        assert(h.isConvertible(Types.JSON))
+        assert(!h.isConvertible(Types.BOOLEAN))
+    }
+
+    test("JsonLogicalTypeHandler.consume() raises DataException if given type is not json") {
+        val h = JsonLogicalTypeHandler
+        val actual = Try(h.consume("invalid", null))
+        assert(actual.isFailure)
+        assert(actual.failed.get.isInstanceOf[DataException])
+    }
 }

--- a/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandler.scala
+++ b/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandler.scala
@@ -1,0 +1,74 @@
+package org.embulk.output.s3_parquet.parquet
+
+import org.embulk.spi.DataException
+import org.embulk.spi.`type`.Types
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.Try
+
+@RunWith(classOf[JUnitRunner])
+class TestLogicalTypeHandler extends FunSuite {
+
+  test("IntLogicalTypeHandler.isConvertible() returns true for long") {
+    val h = Int8LogicalTypeHandler
+
+    assert(h.isConvertible(Types.LONG))
+    assert(!h.isConvertible(Types.BOOLEAN))
+  }
+
+  test("IntLogicalTypeHandler.consume() raises DataException if given type is not long") {
+    val h = Int8LogicalTypeHandler
+    val actual = Try(h.consume("invalid", null))
+
+    assert(actual.isFailure)
+    assert(actual.failed.get.isInstanceOf[DataException])
+  }
+
+
+  test("TimestampMillisLogicalTypeHandler.isConvertible() returns true for timestamp") {
+    val h = TimestampMillisLogicalTypeHandler
+
+    assert(h.isConvertible(Types.TIMESTAMP))
+    assert(!h.isConvertible(Types.BOOLEAN))
+  }
+
+  test("TimestampMillisLogicalTypeHandler.consume() raises DataException if given type is not timestamp") {
+    val h = TimestampMillisLogicalTypeHandler
+    val actual = Try(h.consume("invalid", null))
+
+    assert(actual.isFailure)
+    assert(actual.failed.get.isInstanceOf[DataException])
+  }
+
+
+  test("TimestampMicrosLogicalTypeHandler.isConvertible() returns true for timestamp") {
+    val h = TimestampMicrosLogicalTypeHandler
+
+    assert(h.isConvertible(Types.TIMESTAMP))
+    assert(!h.isConvertible(Types.BOOLEAN))
+  }
+
+  test("TimestampMicrosLogicalTypeHandler.consume() raises DataException if given type is not timestamp") {
+    val h = TimestampMicrosLogicalTypeHandler
+    val actual = Try(h.consume("invalid", null))
+
+    assert(actual.isFailure)
+    assert(actual.failed.get.isInstanceOf[DataException])
+  }
+
+  test("JsonLogicalTypeHandler.isConvertible() returns true for json") {
+    val h = JsonLogicalTypeHandler
+
+    assert(h.isConvertible(Types.JSON))
+    assert(!h.isConvertible(Types.BOOLEAN))
+  }
+
+  test("JsonLogicalTypeHandler.consume() raises DataException if given type is not json") {
+    val h = JsonLogicalTypeHandler
+    val actual = Try(h.consume("invalid", null))
+    assert(actual.isFailure)
+    assert(actual.failed.get.isInstanceOf[DataException])
+  }
+}

--- a/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandlerStore.scala
+++ b/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandlerStore.scala
@@ -1,5 +1,6 @@
 package org.embulk.output.s3_parquet.parquet
 
+
 import java.util.Optional
 
 import com.google.common.base.{Optional => GOptional}
@@ -14,122 +15,149 @@ import org.scalatest.junit.JUnitRunner
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
+
 @RunWith(classOf[JUnitRunner])
-class TestLogicalTypeHandlerStore extends FunSuite {
-  test("empty() returns empty maps") {
-    val rv = LogicalTypeHandlerStore.empty
+class TestLogicalTypeHandlerStore
+    extends FunSuite
+{
+    test("empty() returns empty maps") {
+        val rv = LogicalTypeHandlerStore.empty
 
-    assert(rv.fromColumnName.isEmpty)
-    assert(rv.fromEmbulkType.isEmpty)
-  }
+        assert(rv.fromColumnName.isEmpty)
+        assert(rv.fromEmbulkType.isEmpty)
+    }
 
-  test("fromEmbulkOptions() returns handlers for valid option tasks") {
-    val typeOpts = Map[String, TypeOptionTask](
-      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
-    ).asJava
-    val columnOpts = Map[String, ColumnOptionTask](
-      "col1" -> DummyColumnOptionTask(Optional.of[String]("timestamp-micros")),
-    ).asJava
+    test("fromEmbulkOptions() returns handlers for valid option tasks") {
+        val typeOpts = Map[String, TypeOptionTask](
+            "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+            ).asJava
+        val columnOpts = Map[String, ColumnOptionTask](
+            "col1" -> DummyColumnOptionTask(Optional.of[String]("timestamp-micros")),
+            ).asJava
 
-    val expected1 = Map[EType, LogicalTypeHandler](
-      Types.TIMESTAMP -> TimestampMillisLogicalTypeHandler,
-    )
-    val expected2 = Map[String, LogicalTypeHandler](
-      "col1" -> TimestampMicrosLogicalTypeHandler,
-    )
+        val expected1 = Map[EType, LogicalTypeHandler](
+            Types.TIMESTAMP -> TimestampMillisLogicalTypeHandler,
+            )
+        val expected2 = Map[String, LogicalTypeHandler](
+            "col1" -> TimestampMicrosLogicalTypeHandler,
+            )
 
-    val rv = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+        val rv = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
 
-    assert(rv.fromEmbulkType == expected1)
-    assert(rv.fromColumnName == expected2)
-  }
+        assert(rv.fromEmbulkType == expected1)
+        assert(rv.fromColumnName == expected2)
+    }
 
-  test("fromEmbulkOptions() raises ConfigException if invalid option tasks given") {
-    val emptyTypeOpts = Map.empty[String, TypeOptionTask].asJava
-    val emptyColumnOpts = Map.empty[String, ColumnOptionTask].asJava
+    test("fromEmbulkOptions() raises ConfigException if invalid option tasks given") {
+        val emptyTypeOpts = Map.empty[String, TypeOptionTask].asJava
+        val emptyColumnOpts = Map.empty[String, ColumnOptionTask].asJava
 
-    val invalidTypeOpts = Map[String, TypeOptionTask](
-      "unknown-embulk-type-name" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
-      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("unknown-parquet-logical-type-name")),
-    ).asJava
-    val invalidColumnOpts = Map[String, ColumnOptionTask](
-      "col1" -> DummyColumnOptionTask(Optional.of[String]("unknown-parquet-logical-type-name")),
-    ).asJava
+        val invalidTypeOpts = Map[String, TypeOptionTask](
+            "unknown-embulk-type-name" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+            "timestamp" -> DummyTypeOptionTask(Optional.of[String]("unknown-parquet-logical-type-name")),
+            ).asJava
+        val invalidColumnOpts = Map[String, ColumnOptionTask](
+            "col1" -> DummyColumnOptionTask(Optional.of[String]("unknown-parquet-logical-type-name")),
+            ).asJava
 
-    val try1 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(invalidTypeOpts, emptyColumnOpts))
-    assert(try1.isFailure)
-    assert(try1.failed.get.isInstanceOf[ConfigException])
+        val try1 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(invalidTypeOpts, emptyColumnOpts))
+        assert(try1.isFailure)
+        assert(try1.failed.get.isInstanceOf[ConfigException])
 
-    val try2 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(emptyTypeOpts, invalidColumnOpts))
-    assert(try2.isFailure)
-    assert(try2.failed.get.isInstanceOf[ConfigException])
+        val try2 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(emptyTypeOpts, invalidColumnOpts))
+        assert(try2.isFailure)
+        assert(try2.failed.get.isInstanceOf[ConfigException])
 
-    val try3 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(invalidTypeOpts, invalidColumnOpts))
-    assert(try3.isFailure)
-    assert(try3.failed.get.isInstanceOf[ConfigException])
-  }
+        val try3 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(invalidTypeOpts, invalidColumnOpts))
+        assert(try3.isFailure)
+        assert(try3.failed.get.isInstanceOf[ConfigException])
+    }
 
-  test("get() returns a handler matched with primary column name condition") {
-    val typeOpts = Map[String, TypeOptionTask](
-      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
-    ).asJava
-    val columnOpts = Map[String, ColumnOptionTask](
-      "col1" -> DummyColumnOptionTask(Optional.of[String]("timestamp-micros")),
-    ).asJava
+    test("get() returns a handler matched with primary column name condition") {
+        val typeOpts = Map[String, TypeOptionTask](
+            "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+            ).asJava
+        val columnOpts = Map[String, ColumnOptionTask](
+            "col1" -> DummyColumnOptionTask(Optional.of[String]("timestamp-micros")),
+            ).asJava
 
-    val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+        val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
 
-    // It matches both of column name and embulk type, and column name should be primary
-    val expected = Some(TimestampMicrosLogicalTypeHandler)
-    val actual = handlers.get("col1", Types.TIMESTAMP)
+        // It matches both of column name and embulk type, and column name should be primary
+        val expected = Some(TimestampMicrosLogicalTypeHandler)
+        val actual = handlers.get("col1", Types.TIMESTAMP)
 
-    assert(actual == expected)
-  }
+        assert(actual == expected)
+    }
 
-  test("get() returns a handler matched with type name condition") {
-    val typeOpts = Map[String, TypeOptionTask](
-      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
-    ).asJava
-    val columnOpts = Map.empty[String, ColumnOptionTask].asJava
+    test("get() returns a handler matched with type name condition") {
+        val typeOpts = Map[String, TypeOptionTask](
+            "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+            ).asJava
+        val columnOpts = Map.empty[String, ColumnOptionTask].asJava
 
-    val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+        val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
 
-    // It matches column name
-    val expected = Some(TimestampMillisLogicalTypeHandler)
-    val actual = handlers.get("col1", Types.TIMESTAMP)
+        // It matches column name
+        val expected = Some(TimestampMillisLogicalTypeHandler)
+        val actual = handlers.get("col1", Types.TIMESTAMP)
 
-    assert(actual == expected)
-  }
+        assert(actual == expected)
+    }
 
-  test("get() returns None if not matched") {
-    val typeOpts = Map.empty[String, TypeOptionTask].asJava
-    val columnOpts = Map.empty[String, ColumnOptionTask].asJava
+    test("get() returns None if not matched") {
+        val typeOpts = Map.empty[String, TypeOptionTask].asJava
+        val columnOpts = Map.empty[String, ColumnOptionTask].asJava
 
-    val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+        val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
 
-    // It matches embulk type
-    val actual = handlers.get("col1", Types.TIMESTAMP)
+        // It matches embulk type
+        val actual = handlers.get("col1", Types.TIMESTAMP)
 
-    assert(actual.isEmpty)
-  }
+        assert(actual.isEmpty)
+    }
 
-  private case class DummyTypeOptionTask(lt: Optional[String]) extends TypeOptionTask {
-    override def getLogicalType: Optional[String] = lt
+    private case class DummyTypeOptionTask(lt: Optional[String])
+        extends TypeOptionTask
+    {
+      override def getLogicalType: Optional[String] =
+      {
+        lt
+      }
 
-    override def validate(): Unit = {}
+      override def validate(): Unit =
+        {}
 
-    override def dump(): TaskSource = null
-  }
+      override def dump(): TaskSource =
+      {
+        null
+      }
+    }
 
-  private case class DummyColumnOptionTask(lt: Optional[String]) extends ColumnOptionTask {
-    override def getTimeZoneId: GOptional[String] = GOptional.absent[String]
+    private case class DummyColumnOptionTask(lt: Optional[String])
+        extends ColumnOptionTask
+    {
+      override def getTimeZoneId: GOptional[String] =
+      {
+        GOptional.absent[String]
+      }
 
-    override def getFormat: GOptional[String] = GOptional.absent[String]
+      override def getFormat: GOptional[String] =
+      {
+        GOptional.absent[String]
+      }
 
-    override def getLogicalType: Optional[String] = lt
+      override def getLogicalType: Optional[String] =
+      {
+        lt
+      }
 
-    override def validate(): Unit = {}
+      override def validate(): Unit =
+        {}
 
-    override def dump(): TaskSource = null
-  }
+      override def dump(): TaskSource =
+      {
+        null
+      }
+    }
 }

--- a/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandlerStore.scala
+++ b/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandlerStore.scala
@@ -1,0 +1,135 @@
+package org.embulk.output.s3_parquet.parquet
+
+import java.util.Optional
+
+import com.google.common.base.{Optional => GOptional}
+import org.embulk.config.{ConfigException, TaskSource}
+import org.embulk.output.s3_parquet.S3ParquetOutputPlugin.{ColumnOptionTask, TypeOptionTask}
+import org.embulk.spi.`type`.{Type => EType}
+import org.embulk.spi.`type`.Types
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+@RunWith(classOf[JUnitRunner])
+class TestLogicalTypeHandlerStore extends FunSuite {
+  test("empty() returns empty maps") {
+    val rv = LogicalTypeHandlerStore.empty
+
+    assert(rv.fromColumnName.isEmpty)
+    assert(rv.fromEmbulkType.isEmpty)
+  }
+
+  test("fromEmbulkOptions() returns handlers for valid option tasks") {
+    val typeOpts = Map[String, TypeOptionTask](
+      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+    ).asJava
+    val columnOpts = Map[String, ColumnOptionTask](
+      "col1" -> DummyColumnOptionTask(Optional.of[String]("timestamp-micros")),
+    ).asJava
+
+    val expected1 = Map[EType, LogicalTypeHandler](
+      Types.TIMESTAMP -> TimestampMillisLogicalTypeHandler,
+    )
+    val expected2 = Map[String, LogicalTypeHandler](
+      "col1" -> TimestampMicrosLogicalTypeHandler,
+    )
+
+    val rv = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+
+    assert(rv.fromEmbulkType == expected1)
+    assert(rv.fromColumnName == expected2)
+  }
+
+  test("fromEmbulkOptions() raises ConfigException if invalid option tasks given") {
+    val emptyTypeOpts = Map.empty[String, TypeOptionTask].asJava
+    val emptyColumnOpts = Map.empty[String, ColumnOptionTask].asJava
+
+    val invalidTypeOpts = Map[String, TypeOptionTask](
+      "unknown-embulk-type-name" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("unknown-parquet-logical-type-name")),
+    ).asJava
+    val invalidColumnOpts = Map[String, ColumnOptionTask](
+      "col1" -> DummyColumnOptionTask(Optional.of[String]("unknown-parquet-logical-type-name")),
+    ).asJava
+
+    val try1 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(invalidTypeOpts, emptyColumnOpts))
+    assert(try1.isFailure)
+    assert(try1.failed.get.isInstanceOf[ConfigException])
+
+    val try2 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(emptyTypeOpts, invalidColumnOpts))
+    assert(try2.isFailure)
+    assert(try2.failed.get.isInstanceOf[ConfigException])
+
+    val try3 = Try(LogicalTypeHandlerStore.fromEmbulkOptions(invalidTypeOpts, invalidColumnOpts))
+    assert(try3.isFailure)
+    assert(try3.failed.get.isInstanceOf[ConfigException])
+  }
+
+  test("get() returns a handler matched with primary column name condition") {
+    val typeOpts = Map[String, TypeOptionTask](
+      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+    ).asJava
+    val columnOpts = Map[String, ColumnOptionTask](
+      "col1" -> DummyColumnOptionTask(Optional.of[String]("timestamp-micros")),
+    ).asJava
+
+    val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+
+    // It matches both of column name and embulk type, and column name should be primary
+    val expected = Some(TimestampMicrosLogicalTypeHandler)
+    val actual = handlers.get("col1", Types.TIMESTAMP)
+
+    assert(actual == expected)
+  }
+
+  test("get() returns a handler matched with type name condition") {
+    val typeOpts = Map[String, TypeOptionTask](
+      "timestamp" -> DummyTypeOptionTask(Optional.of[String]("timestamp-millis")),
+    ).asJava
+    val columnOpts = Map.empty[String, ColumnOptionTask].asJava
+
+    val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+
+    // It matches column name
+    val expected = Some(TimestampMillisLogicalTypeHandler)
+    val actual = handlers.get("col1", Types.TIMESTAMP)
+
+    assert(actual == expected)
+  }
+
+  test("get() returns None if not matched") {
+    val typeOpts = Map.empty[String, TypeOptionTask].asJava
+    val columnOpts = Map.empty[String, ColumnOptionTask].asJava
+
+    val handlers = LogicalTypeHandlerStore.fromEmbulkOptions(typeOpts, columnOpts)
+
+    // It matches embulk type
+    val actual = handlers.get("col1", Types.TIMESTAMP)
+
+    assert(actual.isEmpty)
+  }
+
+  private case class DummyTypeOptionTask(lt: Optional[String]) extends TypeOptionTask {
+    override def getLogicalType: Optional[String] = lt
+
+    override def validate(): Unit = {}
+
+    override def dump(): TaskSource = null
+  }
+
+  private case class DummyColumnOptionTask(lt: Optional[String]) extends ColumnOptionTask {
+    override def getTimeZoneId: GOptional[String] = GOptional.absent[String]
+
+    override def getFormat: GOptional[String] = GOptional.absent[String]
+
+    override def getLogicalType: Optional[String] = lt
+
+    override def validate(): Unit = {}
+
+    override def dump(): TaskSource = null
+  }
+}


### PR DESCRIPTION
Parquet supports [LogicalTypes](https://github.com/apache/parquet-format/blob/2b38663/LogicalTypes.md) to enrich primitive types and its sometimes useful to integrate data processing on infrastructures(e.g. Handling timestamp columns and using timestamp-specific functions). `embulk-output-s3_parquet` supports it on only limited use cases but we probably need more types and flexible configurations.

So in the patch, I implement `LogicalTypeHandler` to process schema/value conversion flexibly and  both of column names/embulk types based configurations(extended `column_options` and `type_options`)