### PR TITLE
Update dependencies & Support auth_method: web_identity_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - **page_size**: The page size is for compression. When reading, each page can be decompressed independently. A block is composed of pages. The page is the smallest unit that must be read fully to access a single record. If this value is too small, the compression will deteriorate. (int, default: `1048576` (1MB))
 - **max_padding_size**: The max size (bytes) to write as padding and the min size of a row group (int, default: `8388608` (8MB))
 - **enable_dictionary_encoding**: The boolean value is to enable/disable dictionary encoding. (boolean, default: `true`)
-- **auth_method**: name of mechanism to authenticate requests (`"basic"`, `"env"`, `"instance"`, `"profile"`, `"properties"`, `"anonymous"`, or `"session"`, default: `"default"`)
+- **auth_method**: name of mechanism to authenticate requests (`"basic"`, `"env"`, `"instance"`, `"profile"`, `"properties"`, `"anonymous"`, `"session"`, `"web_identity_token"`, default: `"default"`)
   - `"basic"`: uses **access_key_id** and **secret_access_key** to authenticate.
   - `"env"`: uses `AWS_ACCESS_KEY_ID` (or `AWS_ACCESS_KEY`) and `AWS_SECRET_KEY` (or `AWS_SECRET_ACCESS_KEY`) environment variables.
   - `"instance"`: uses EC2 instance profile or attached ECS task role.
@@ -47,6 +47,7 @@
   - `"anonymous"`: uses anonymous access. This auth method can access only public files.
   - `"session"`: uses temporary-generated **access_key_id**, **secret_access_key** and **session_token**.
   - `"assume_role"`: uses temporary-generated credentials by assuming **role_arn** role.
+  - `"web_identity_token"`: uses temporary-generated credentials by assuming **role_arn** role with web identity.
   - `"default"`: uses AWS SDK's default strategy to look up available credentials from runtime environment. This method behaves like the combination of the following methods.
     1. `"env"`
     1. `"properties"`
@@ -57,10 +58,11 @@
 - **access_key_id**: aws access key id. this is required when **auth_method** is `"basic"` or `"session"`. (string, optional)
 - **secret_access_key**: aws secret access key. this is required when **auth_method** is `"basic"` or `"session"`. (string, optional)
 - **session_token**: aws session token. this is required when **auth_method** is `"session"`. (string, optional)
-- **role_arn**: arn of the role to assume. this is required for **auth_method** is `"assume_role"`. (string, optional)
-- **role_session_name**: an identifier for the assumed role session. this is required when **auth_method** is `"assume_role"`. (string, optional)  
+- **role_arn**: arn of the role to assume. this is required for **auth_method** is `"assume_role"` or `"web_identity_token"`. (string, optional)
+- **role_session_name**: an identifier for the assumed role session. this is required when **auth_method** is `"assume_role"` or `"web_identity_token"`. (string, optional)
 - **role_external_id**: a unique identifier that is used by third parties when assuming roles in their customers' accounts. this is optionally used for **auth_method**: `"assume_role"`. (string, optional)
-- **role_session_duration_seconds**: duration, in seconds, of the role session. this is optionally used for **auth_method**: `"assume_role"`. (int, optional) 
+- **role_session_duration_seconds**: duration, in seconds, of the role session. this is optionally used for **auth_method**: `"assume_role"`. (int, optional)
+- **web_identity_token_file**: the absolute path to the web identity token file. this is required when **auth_method** is `"web_identity_token"`. (string, optional)
 - **scope_down_policy**: an iam policy in json format. this is optionally used for **auth_method**: `"assume_role"`. (string, optional)
 - **catalog**: Register a table if this option is specified (optional)
   - **catalog_id**: glue data catalog id if you use a catalog different from account/region default catalog. (string, optional)

--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,12 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.9.17"
-    provided "org.embulk:embulk-core:0.9.17"
+    compile  "org.embulk:embulk-core:0.9.20"
+    provided "org.embulk:embulk-core:0.9.20"
 
-    compile 'org.scala-lang:scala-library:2.13.0'
+    compile 'org.scala-lang:scala-library:2.13.1'
     ['glue', 's3', 'sts'].each { v ->
-        compile "com.amazonaws:aws-java-sdk-${v}:1.11.592"
+        compile "com.amazonaws:aws-java-sdk-${v}:1.11.676"
     }
     ['column', 'common', 'encoding', 'format', 'hadoop', 'jackson'].each { v ->
         compile "org.apache.parquet:parquet-${v}:1.10.1"
@@ -33,8 +33,8 @@ dependencies {
     compile 'org.xerial.snappy:snappy-java:1.1.7.3'
 
     testCompile 'org.scalatest:scalatest_2.13:3.0.8'
-    testCompile 'org.embulk:embulk-test:0.9.17'
-    testCompile 'org.embulk:embulk-standards:0.9.17'
+    testCompile 'org.embulk:embulk-test:0.9.20'
+    testCompile 'org.embulk:embulk-standards:0.9.20'
     testCompile 'org.apache.parquet:parquet-tools:1.10.1'
     testCompile 'org.apache.hadoop:hadoop-client:2.9.2'
 }

--- a/src/test/scala/org/embulk/output/s3_parquet/TestS3ParquetOutputPlugin.scala
+++ b/src/test/scala/org/embulk/output/s3_parquet/TestS3ParquetOutputPlugin.scala
@@ -18,7 +18,7 @@ import org.embulk.test.{EmbulkTests, TestingEmbulk}
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, DiagrammedAssertions, FunSuite}
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 import scala.annotation.meta.getter
 import scala.jdk.CollectionConverters._

--- a/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandler.scala
+++ b/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandler.scala
@@ -5,7 +5,7 @@ import org.embulk.spi.DataException
 import org.embulk.spi.`type`.Types
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 import scala.util.Try
 

--- a/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandlerStore.scala
+++ b/src/test/scala/org/embulk/output/s3_parquet/parquet/TestLogicalTypeHandlerStore.scala
@@ -6,11 +6,10 @@ import java.util.Optional
 import com.google.common.base.{Optional => GOptional}
 import org.embulk.config.{ConfigException, TaskSource}
 import org.embulk.output.s3_parquet.S3ParquetOutputPlugin.{ColumnOptionTask, TypeOptionTask}
-import org.embulk.spi.`type`.{Type => EType}
-import org.embulk.spi.`type`.Types
+import org.embulk.spi.`type`.{Types, Type => EType}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 import scala.jdk.CollectionConverters._
 import scala.util.Try
@@ -120,44 +119,44 @@ class TestLogicalTypeHandlerStore
     private case class DummyTypeOptionTask(lt: Optional[String])
         extends TypeOptionTask
     {
-      override def getLogicalType: Optional[String] =
-      {
-        lt
-      }
+        override def getLogicalType: Optional[String] =
+        {
+            lt
+        }
 
-      override def validate(): Unit =
+        override def validate(): Unit =
         {}
 
-      override def dump(): TaskSource =
-      {
-        null
-      }
+        override def dump(): TaskSource =
+        {
+            null
+        }
     }
 
     private case class DummyColumnOptionTask(lt: Optional[String])
         extends ColumnOptionTask
     {
-      override def getTimeZoneId: GOptional[String] =
-      {
-        GOptional.absent[String]
-      }
+        override def getTimeZoneId: GOptional[String] =
+        {
+            GOptional.absent[String]
+        }
 
-      override def getFormat: GOptional[String] =
-      {
-        GOptional.absent[String]
-      }
+        override def getFormat: GOptional[String] =
+        {
+            GOptional.absent[String]
+        }
 
-      override def getLogicalType: Optional[String] =
-      {
-        lt
-      }
+        override def getLogicalType: Optional[String] =
+        {
+            lt
+        }
 
-      override def validate(): Unit =
+        override def validate(): Unit =
         {}
 
-      override def dump(): TaskSource =
-      {
-        null
-      }
+        override def dump(): TaskSource =
+        {
+            null
+        }
     }
 }


### PR DESCRIPTION
* update dependencies (embulk 0.9.17 -> 0.9.20, scala 2.13.0 -> 2.13.1, aws-sdk 1.11.592 -> 1.11.676)
* Support auth_method: web_identity_token for the EKS "IAM Roles for Service Accounts" feature.
* Use `org.scalatestplus.junit.JUnitRunner` instead of `org.scalatest.junit.JUnitRunner`.