### PR TITLE
Fix a bug: Use basic credentials correctly

### DIFF
--- a/src/main/scala/org/embulk/output/s3_parquet/aws/AwsCredentials.scala
+++ b/src/main/scala/org/embulk/output/s3_parquet/aws/AwsCredentials.scala
@@ -89,7 +89,7 @@ class AwsCredentials(task: Task) {
         new AWSStaticCredentialsProvider(
           new BasicAWSCredentials(
             getRequiredOption(task.getAccessKeyId, "access_key_id"),
-            getRequiredOption(task.getAccessKeyId, "secret_access_key")
+            getRequiredOption(task.getSecretAccessKey, "secret_access_key")
           )
         )
 


### PR DESCRIPTION
Follow up https://github.com/civitaspo/embulk-output-s3_parquet/pull/18

- [BugFix] Use basic credentials correctly