### PR TITLE
Github Actions releases automatically when a new release tag pushed instead of releasing from local.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: Release CI
 
 on:
-  pull_request:
-    branches:
-      - master
-    types:
-      - closed
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:


### PR DESCRIPTION
* Do not use `develop` branch anymore.
* Do not release a new gem from local. Github Actions releases automatically when a new release tag pushed instead.