### PR TITLE
Ship v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.4.0 (2020-04-28)
+==================
+
+* [Enhancement] [#35](https://github.com/civitaspo/embulk-output-s3_parquet/pull/35) Fix deprecation warnings.
+
+
 0.3.0 (2020-04-26)
 ==================
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "pro.civitaspo"
-version = "0.3.0"
+version = "0.4.0"
 description = "Dumps records to S3 Parquet."
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
0.4.0 (2020-04-28)
==================

* [Enhancement] [#35](https://github.com/civitaspo/embulk-output-s3_parquet/pull/35) Fix deprecation warnings.