### PR TITLE
Ship v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.5.1 (2020-06-24)
+==================
+
+* [Fix] [#47](https://github.com/civitaspo/embulk-output-s3_parquet/pull/47) Use lower case without any space for Glue data type.
+
 0.5.0 (2020-05-25)
 ==================
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "pro.civitaspo"
-version = "0.5.0"
+version = "0.5.1"
 description = "Dumps records to S3 Parquet."
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
0.5.1 (2020-06-24)
==================

* [Fix] [#47](https://github.com/civitaspo/embulk-output-s3_parquet/pull/47) Use lower case without any space for Glue data type.