### PR TITLE
Ship v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.5.2 (2020-10-12)
+==================
+
+* [Fix] [#51](https://github.com/civitaspo/embulk-output-s3_parquet/pull/51) Use PluginClassLoader when oparating catalog.
+
 0.5.1 (2020-06-24)
 ==================
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "pro.civitaspo"
-version = "0.5.1"
+version = "0.5.2"
 description = "Dumps records to S3 Parquet."
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
* [Fix] [#51](https://github.com/civitaspo/embulk-output-s3_parquet/pull/51) Use PluginClassLoader when oparating catalog.